### PR TITLE
[ADD] connector_helpscout: Create HelpScout User sync

### DIFF
--- a/connector_helpscout/README.rst
+++ b/connector_helpscout/README.rst
@@ -29,6 +29,10 @@ To configure this module, you need to:
 Usage
 =====
 
+Note: Odoo user emails are assumed to be correct. If Odoo user logins are more
+likely to match your HelpScout users' email addresses, select 'Login' in the
+HelpScout connector backend settings.
+
 To use this module, you need to:
 
 #. Go to ...

--- a/connector_helpscout/__manifest__.py
+++ b/connector_helpscout/__manifest__.py
@@ -24,6 +24,7 @@
     ],
     "data": [
         "security/ir.model.access.csv",
+        "security/helpscout_security.xml",
         "views/helpscout_backend_view.xml",
         "views/helpscout_web_hook_view.xml",
         "views/connector_menu.xml",

--- a/connector_helpscout/__manifest__.py
+++ b/connector_helpscout/__manifest__.py
@@ -20,6 +20,7 @@
         "partner_firstname",
         "project",
         "queue_job",
+        "sales_team",
     ],
     "data": [
         "security/ir.model.access.csv",

--- a/connector_helpscout/components/binder.py
+++ b/connector_helpscout/components/binder.py
@@ -12,4 +12,5 @@ class HelpScoutModelBinder(Component):
     _inherit = ['base.binder', 'base.helpscout.connector']
     _apply_on = [
         'helpscout.customer',
+        'helpscout.user',
     ]

--- a/connector_helpscout/components/listener.py
+++ b/connector_helpscout/components/listener.py
@@ -27,6 +27,7 @@ class HelpScoutListenerBinding(Component):
     _inherit = 'helpscout.listener'
     _apply_on = [
         'helpscout.customer',
+        'helpscout.user',
     ]
 
     @skip_if(lambda self, record, **kwargs: self.no_connector_export(record))
@@ -51,6 +52,7 @@ class HelpScoutListenerOdoo(Component):
     _inherit = 'helpscout.listener'
     _apply_on = [
         'res.partner',
+        'res.users',
     ]
 
     def new_binding(self, record):

--- a/connector_helpscout/components/listener.py
+++ b/connector_helpscout/components/listener.py
@@ -50,7 +50,7 @@ class HelpScoutListenerOdoo(Component):
     _name = 'helpscout.listener.odoo'
     _inherit = 'helpscout.listener'
     _apply_on = [
-        'helpscout.customer',
+        'res.partner',
     ]
 
     def new_binding(self, record):

--- a/connector_helpscout/models/__init__.py
+++ b/connector_helpscout/models/__init__.py
@@ -7,6 +7,7 @@ from . import helpscout_binding
 
 # Models
 from . import helpscout_customer
+from . import helpscout_user
 
 # Web Hook
 from . import helpscout_web_hook

--- a/connector_helpscout/models/helpscout_backend/common.py
+++ b/connector_helpscout/models/helpscout_backend/common.py
@@ -25,6 +25,7 @@ class HelpscoutBackend(models.Model):
 
     EVENT_TO_MODEL = {
         'customer': 'helpscout.customer',
+        'user': 'helpscout.user',
         'satisfaction': 'helpscout.rating',
         'convo': 'helpscout.conversation',
     }
@@ -59,6 +60,7 @@ class HelpscoutBackend(models.Model):
     # These dates are used by the import crons to start where left off.
     import_customers_from_date = fields.Datetime()
     import_mailboxes_from_date = fields.Datetime()
+    import_users_from_date = fields.Datetime()
 
     @property
     @api.model
@@ -165,6 +167,12 @@ class HelpscoutBackend(models.Model):
         """Trigger an import for customers on the appropriate from field."""
         self.import_from_date('helpscout.customer',
                               'import_customers_from_date')
+
+    @api.multi
+    def action_import_users(self):
+        """Trigger an import for users on the appropriate from field."""
+        self.import_from_date('helpscout.user',
+                              'import_users_from_date')
 
     @api.multi
     def action_receive_hook(self, event_type, signature, data_str):

--- a/connector_helpscout/models/helpscout_backend/common.py
+++ b/connector_helpscout/models/helpscout_backend/common.py
@@ -56,6 +56,18 @@ class HelpscoutBackend(models.Model):
              'this company, that are not otherwise assigned to a HelpScout '
              'backend.',
     )
+    user_match_field = fields.Selection(
+        selection=[
+            ('email', 'Email'),
+            ('login', 'Login'),
+        ],
+        required=True,
+        default='email',
+        string='User Match Field',
+        help='Select which Odoo user field to use when matching imported '
+             'Helpscout users to existing Odoo users. This field will be '
+             'matched against the Helpscout user\'s email address.'
+    )
 
     # These dates are used by the import crons to start where left off.
     import_customers_from_date = fields.Datetime()

--- a/connector_helpscout/models/helpscout_customer/exporter.py
+++ b/connector_helpscout/models/helpscout_customer/exporter.py
@@ -15,7 +15,7 @@ class HelpScoutCustomerExportMapper(Component):
     direct = [(none('firstname'), 'first_name'),
               (none('lastname'), 'last_name'),
               (none('comment'), 'background'),
-              (none('title'), 'job_title'),
+              (none('function'), 'job_title'),
               ]
 
     @mapping
@@ -48,6 +48,6 @@ class HelpScoutCustomerExportMapper(Component):
 
 class HelpScoutCustomerExporter(Component):
     """Export one HelpScout record."""
-    _name = 'helpscut.customer.record.exporter'
+    _name = 'helpscout.customer.record.exporter'
     _inherit = 'helpscout.exporter'
     _apply_on = 'helpscout.customer'

--- a/connector_helpscout/models/helpscout_customer/importer.py
+++ b/connector_helpscout/models/helpscout_customer/importer.py
@@ -14,7 +14,7 @@ class HelpScoutCustomerImportMapper(Component):
     direct = [(none('first_name'), 'firstname'),
               (none('last_name'), 'lastname'),
               (none('background'), 'comment'),
-              (none('job_title'), 'title'),
+              (none('job_title'), 'function'),
               ('created_at', 'backend_date_created'),
               ('modified_at', 'backend_date_modified'),
               ]

--- a/connector_helpscout/models/helpscout_customer/importer.py
+++ b/connector_helpscout/models/helpscout_customer/importer.py
@@ -33,10 +33,11 @@ class HelpScoutCustomerImportMapper(Component):
         # excluding internal users
         try:
             customer = self.env['res.partner'].search([
-                ('email', '=', record.emails[0].value),
+                ('email', '=', self.email(record)['email']),
                 ('user_id', '=', False),
             ])
-        except IndexError:
+        except AttributeError:
+            # In case no email is found
             return
 
         if customer:

--- a/connector_helpscout/models/helpscout_customer/importer.py
+++ b/connector_helpscout/models/helpscout_customer/importer.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo.addons.component.core import Component
-from odoo.addons.connector.components.mapper import mapping, none
+from odoo.addons.connector.components.mapper import mapping, none, only_create
 
 
 class HelpScoutCustomerImportMapper(Component):
@@ -25,6 +25,22 @@ class HelpScoutCustomerImportMapper(Component):
             return {'email': record.emails[0].value}
         except IndexError:
             return
+
+    @mapping
+    @only_create
+    def odoo_id(self, record):
+        # Searches res.partner records for matching email address,
+        # excluding internal users
+        try:
+            customer = self.env['res.partner'].search([
+                ('email', '=', record.emails[0].value),
+                ('user_id', '=', False),
+            ])
+        except IndexError:
+            return
+
+        if customer:
+            return {'odoo_id': customer.id}
 
     @mapping
     def phones(self, record):

--- a/connector_helpscout/models/helpscout_user/__init__.py
+++ b/connector_helpscout/models/helpscout_user/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import common
+from . import importer

--- a/connector_helpscout/models/helpscout_user/common.py
+++ b/connector_helpscout/models/helpscout_user/common.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields
+from odoo.addons.component.core import Component
+
+
+class ResUsers(models.Model):
+
+    _inherit = 'res.users'
+
+    helpscout_bind_ids = fields.One2many(
+        string='HelpScout Bindings',
+        comodel_name='helpscout.user',
+        inverse_name='odoo_id',
+    )
+
+
+class HelpScoutUser(models.Model):
+
+    _name = 'helpscout.user'
+    _inherit = 'helpscout.binding'
+    _inherits = {'res.users': 'odoo_id'}
+    _description = 'HelpScout Users'
+
+    _rec_name = 'name'
+
+    helpscout_type = fields.Selection(
+        selection=[
+            ('user', 'User'),
+            ('team', 'Team'),
+        ],
+        string="HelpScout type",
+    )
+    odoo_id = fields.Many2one(
+        string='User',
+        comodel_name='res.users',
+        required=True,
+        ondelete='cascade',
+    )
+
+
+class HelpScoutUserAdapter(Component):
+    """Utilize the API in context."""
+    _name = 'helpscout.user.adapter'
+    _inherit = 'helpscout.adapter'
+    _apply_on = 'helpscout.user'
+    _helpscout_endpoint = 'Users'
+
+    def search(self, filters=None):
+        """Return entire user list (there is no search endpoint for Users)"""
+        return [r.id for r in self.endpoint.list()]

--- a/connector_helpscout/models/helpscout_user/importer.py
+++ b/connector_helpscout/models/helpscout_user/importer.py
@@ -29,8 +29,11 @@ class HelpScoutUserImportMapper(Component):
     @mapping
     @only_create
     def odoo_id(self, record):
+        # Searches res.users records for matching email address,
+        # excluding non-internal-users (e.g. customer users)
         user = self.env['res.users'].search([
             (self.backend_record.user_match_field, '=', record.email),
+            ('share', '=', False),
         ])
         if user:
             return {'odoo_id': user.id}

--- a/connector_helpscout/models/helpscout_user/importer.py
+++ b/connector_helpscout/models/helpscout_user/importer.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import logging
+import urllib2
+
+from odoo.addons.component.core import Component
+from odoo.addons.connector.components.mapper import mapping, none
+
+_logger = logging.getLogger(__name__)
+
+
+class HelpScoutUserImportMapper(Component):
+    _name = 'helpscout.import.mapper.user'
+    _inherit = 'helpscout.import.mapper'
+    _apply_on = 'helpscout.user'
+
+    direct = [(none('first_name'), 'firstname'),
+              (none('last_name'), 'lastname'),
+              (none('email'), 'login'),
+              (none('email'), 'email'),
+              (none('timezone'), 'tz'),
+              (none('type'), 'helpscout_type'),
+              ('created_at', 'backend_date_created'),
+              ('modified_at', 'backend_date_modified'),
+              ]
+
+    @mapping
+    def photo_url(self, record):
+        try:
+            image = urllib2.urlopen(record.photo_url).read().encode('base64')
+            return {'image': image}
+        except Exception:
+            _logger.debug('HelpScout photo not imported')
+            return
+
+    @mapping
+    def role(self, record):
+        group_xml_id = "connector_helpscout.group_helpscout_%s" % record.role
+        helpscout_group = self.env.ref(group_xml_id)
+        return {'groups_id': [(6, 0, [helpscout_group.id])]}
+
+
+class HelpScoutUserImporter(Component):
+    """Import one HelpScout record."""
+    _name = 'helpscout.record.importer.user'
+    _inherit = 'helpscout.importer'
+    _apply_on = 'helpscout.user'
+
+
+class HelpScoutUserBatchImporter(Component):
+    """Import a batch of HelpScout records."""
+    _name = 'helpscout.batch.importer.user'
+    _inherit = 'helpscout.direct.batch.importer'
+    _apply_on = 'helpscout.user'

--- a/connector_helpscout/models/helpscout_user/importer.py
+++ b/connector_helpscout/models/helpscout_user/importer.py
@@ -6,7 +6,7 @@ import logging
 import urllib2
 
 from odoo.addons.component.core import Component
-from odoo.addons.connector.components.mapper import mapping, none
+from odoo.addons.connector.components.mapper import mapping, none, only_create
 
 _logger = logging.getLogger(__name__)
 
@@ -18,13 +18,22 @@ class HelpScoutUserImportMapper(Component):
 
     direct = [(none('first_name'), 'firstname'),
               (none('last_name'), 'lastname'),
-              (none('email'), 'login'),
-              (none('email'), 'email'),
+              ('email', 'login'),
+              ('email', 'email'),
               (none('timezone'), 'tz'),
               (none('type'), 'helpscout_type'),
               ('created_at', 'backend_date_created'),
               ('modified_at', 'backend_date_modified'),
               ]
+
+    @mapping
+    @only_create
+    def odoo_id(self, record):
+        user = self.env['res.users'].search([
+            (self.backend_record.user_match_field, '=', record.email),
+        ])
+        if user:
+            return {'odoo_id': user.id}
 
     @mapping
     def photo_url(self, record):

--- a/connector_helpscout/security/helpscout_security.xml
+++ b/connector_helpscout/security/helpscout_security.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2017 LasLabs Inc.
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
+
+<odoo>
+    <record id="ir_module_category_helpscout" model="ir.module.category">
+        <field name="name">HelpScout</field>
+        <field name="sequence">10</field>
+    </record>
+
+    <record id="group_helpscout_user" model="res.groups">
+        <field name="name">User</field>
+        <field name="category_id" ref="ir_module_category_helpscout"/>
+        <field name="users" eval="[(4, ref('base.user_root'))]"/>
+        <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
+    </record>
+
+    <record id="group_helpscout_admin" model="res.groups">
+        <field name="name">Admin</field>
+        <field name="category_id" ref="ir_module_category_helpscout"/>
+        <field name="implied_ids" eval="[(4, ref('group_helpscout_user'))]"/>
+    </record>
+
+    <record id="group_helpscout_owner" model="res.groups">
+        <field name="name">Owner</field>
+        <field name="category_id" ref="ir_module_category_helpscout"/>
+        <field name="implied_ids" eval="[(4, ref('group_helpscout_admin'))]"/>
+    </record>
+</odoo>

--- a/connector_helpscout/security/ir.model.access.csv
+++ b/connector_helpscout/security/ir.model.access.csv
@@ -4,3 +4,4 @@
 "access_helpscout_backend_user","helpscout_backend user","model_helpscout_backend","sales_team.group_sale_salesman",1,0,0,0
 "access_helpscout_backend_sale_manager","helpscout_backend manager","model_helpscout_backend","sales_team.group_sale_manager",1,0,0,0
 "access_helpscout_customer_user","helpscout_customer user","model_helpscout_customer","base.group_user",1,1,1,1
+"access_helpscout_user","helpscout user","model_helpscout_user","base.group_user",1,0,0,0

--- a/connector_helpscout/views/helpscout_backend_view.xml
+++ b/connector_helpscout/views/helpscout_backend_view.xml
@@ -22,7 +22,7 @@
                     <group name="group_helpscout"
                            string="HelpScout Configuration">
                         <group>
-                            <field name="api_key" />
+                            <field name="api_key" password="1" />
                         </group>
                         <group>
                             <field name="company_id" />
@@ -64,6 +64,20 @@
                                            nolabel="1" />
                                 </div>
                                 <button name="action_import_mailboxes"
+                                        type="object"
+                                        class="oe_highlight"
+                                        string="Queue Import" />
+                            </group>
+                            <group name="group_import_users">
+                                <div>
+                                    <label for="import_users_from_date"
+                                           string="Import Users From"
+                                           class="oe_inline" />
+                                    <field name="import_users_from_date"
+                                           class="oe_inline"
+                                           nolabel="1" />
+                                </div>
+                                <button name="action_import_users"
                                         type="object"
                                         class="oe_highlight"
                                         string="Queue Import" />

--- a/connector_helpscout/views/helpscout_backend_view.xml
+++ b/connector_helpscout/views/helpscout_backend_view.xml
@@ -83,6 +83,11 @@
                                         string="Queue Import" />
                             </group>
                         </page>
+                        <page name="page_settings" string="Settings">
+                            <group name="group_users" string="Users">
+                                <field name="user_match_field" />
+                            </group>
+                        </page>
                     </notebook>
 
                 </sheet>


### PR DESCRIPTION
Adds User syncing (import-only, due to API limitations) to `connector_helpscout` module.

Also includes minor fixes to core module and Customer sync.